### PR TITLE
Don't use URL literals in Flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
-  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-22.11;
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
 
-  inputs.fenix.url = github:nix-community/fenix;
+  inputs.fenix.url = "github:nix-community/fenix";
   inputs.fenix.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs = { self, nixpkgs, fenix }:


### PR DESCRIPTION
URL literals do not offer any advantage over strings and many users disable them in their Nix config

Also see https://github.com/StardustXR/server/pull/16
